### PR TITLE
Removed PIL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 images
+*.png
 
 venv
 *.pyc
@@ -42,3 +43,5 @@ nosetests.xml
 #Intellj Idea
 .idea
 *.iml
+
+*.world

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Pillow==2.6.1
 PyPlatec==1.1
+langgen==0.1.2
 argparse==1.2.1
 noise==1.2.1
 nose==1.3.1


### PR DESCRIPTION
I came across your generator and tried installing it, but I was having some issues installing PIL.  While browsing Stack Exchange I found several people recommending that people use a fork of PIL called Pillow.  I did so and got it working.  Pillow can be installed from pip without the issues PIL has.  Here are mt changes if you are interested.
