### PR TITLE
Trivial fix with Greyscale

### DIFF
--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -68,7 +68,7 @@ def generate_world(world_name, width, height, seed, num_plates, output_dir,
 
 
 def generate_grayscale_heightmap(world, filename):
-    draw_grayscale_heightmap(world, filename)
+    draw_grayscale_heightmap_on_file(world, filename)
     print("+ grayscale heightmap generated in '%s'" % filename)
 
 


### PR DESCRIPTION
We have now generic functions (like `draw_grayscale_heightmap`) which can be used both for the GUI and to write on image files. Then we have functions like `draw_grayscale_heightmap_on_file` which wraps them, executing the drawing on file.

We were using the wrong one in this case :(