### PR TITLE
move to numpy 1.9.2

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -4,4 +4,4 @@ langgen==0.1.2
 argparse==1.2.1
 noise==1.2.2
 nose==1.3.1
-numpy==1.9.1
+numpy==1.9.2

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ config = {
     },
     'install_requires': ['Pillow==2.6.1', 'PyPlatec==1.3.1.post1', 'langgen==0.1.2',
                          'argparse==1.2.1', 'noise==1.2.2', 'nose==1.3.1',
-                         'wsgiref==0.1.2', 'protobuf==2.6.0', 'numpy==1.9.1'],
+                         'wsgiref==0.1.2', 'protobuf==2.6.0', 'numpy==1.9.2'],
     'name': 'worldengine'
 }
 


### PR DESCRIPTION
Open a Pull Request so that Travis and AppVeyor verify if everything is fine with Numpy 1.9.2

The reason to move to Numpy 1.9.2 is that previous versions has no wheel packages for Windows as reported by @SourceRyan (see #69)