### PR TITLE
Parameter ocean_level was not passed to platec.

### DIFF
--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -297,7 +297,7 @@ def main():
                             dest='grayscale_heightmap', action="store_true",
                             help='produce a grayscale heightmap')
     g_generate.add_argument('--ocean_level', dest='ocean_level', type=float,
-                            help='elevation cut off for sea level " +'
+                            help='amount of surface covered by ocean " +'
                                  '[default = %(default)s]',
                             metavar="N", default=1.0)
 

--- a/worldengine/generation.py
+++ b/worldengine/generation.py
@@ -98,16 +98,18 @@ def fill_ocean(elevation, sea_level):
 
     ocean = [[False for x in range(width)] for y in range(height)]  # TODO: use numpy
     to_expand = []
-    for x in range(width):
+    for x in range(width):#handle top and bottom border of the map
         if elevation[0][x] <= sea_level:
             to_expand.append((x, 0))
         if elevation[height - 1][x] <= sea_level:
             to_expand.append((x, height - 1))
-    for y in range(height):
+    for y in range(height):#handle left- and rightmost border of the map
         if elevation[y][0] <= sea_level:
             to_expand.append((0, y))
         if elevation[y][width - 1] <= sea_level:
             to_expand.append((width - 1, y))
+
+    #generate the ocean, starting on borders and then moving inwards
     for t in to_expand:
         tx, ty = t
         if not ocean[ty][tx]:
@@ -119,24 +121,30 @@ def fill_ocean(elevation, sea_level):
     return ocean
 
 
-def initialize_ocean_and_thresholds(world, ocean_level=1.0):
+def initialize_ocean_and_thresholds(world, ocean_level=0.65):
     """
     Calculate the ocean, the sea depth and the elevation thresholds
     :param world: a world having elevation but not thresholds
-    :param ocean_level: the elevation representing the ocean level
+    :param ocean_level: the amount of surface area covered by ocean
     :return: nothing, the world will be changed
     """
     e = world.elevation['data']
-    ocean = fill_ocean(e, ocean_level)
+
+    #Calculate the height of the ocean relative to the geometry
+    ocean_maxlevel = find_threshold_f(e, 1.0 - ocean_level,
+                                      ocean=None, max=1.0, mindist=0.00001)
+    #end of calculation    
+    
+    ocean = fill_ocean(e, ocean_maxlevel)
     hl = find_threshold_f(e, 0.10)
     ml = find_threshold_f(e, 0.03)
-    e_th = [('sea', ocean_level),
+    e_th = [('sea', ocean_maxlevel),
             ('plain', hl),
             ('hill', ml),
             ('mountain', None)]
     world.set_ocean(ocean)
     world.set_elevation(e, e_th)
-    world.sea_depth = sea_depth(world, ocean_level)
+    world.sea_depth = sea_depth(world, ocean_maxlevel)
 
 
 # ----

--- a/worldengine/plates.py
+++ b/worldengine/plates.py
@@ -11,7 +11,7 @@ from worldengine.common import array_to_matrix
 from world import World
 
 
-def generate_plates_simulation(seed, width, height, sea_level=0.65,
+def generate_plates_simulation(seed, width, height, ocean_level=1.0,
                                erosion_period=60, folding_ratio=0.02,
                                aggr_overlap_abs=1000000, aggr_overlap_rel=0.33,
                                cycle_count=2, num_plates=10,
@@ -19,7 +19,7 @@ def generate_plates_simulation(seed, width, height, sea_level=0.65,
 
     if verbose:
         start_time = time.time()
-    p = platec.create(seed, width, height, sea_level, erosion_period,
+    p = platec.create(seed, width, height, ocean_level, erosion_period,
                       folding_ratio, aggr_overlap_abs, aggr_overlap_rel,
                       cycle_count, num_plates)
 
@@ -39,6 +39,7 @@ def _plates_simulation(name, width, height, seed, num_plates=10,
                        ocean_level=1.0, step=Step.full(),
                        verbose=get_verbose()):
     e_as_array, p_as_array = generate_plates_simulation(seed, width, height,
+                                                        ocean_level=ocean_level,
                                                         num_plates=num_plates,
                                                         verbose=verbose)
 

--- a/worldengine/plates.py
+++ b/worldengine/plates.py
@@ -11,7 +11,7 @@ from worldengine.common import array_to_matrix
 from world import World
 
 
-def generate_plates_simulation(seed, width, height, ocean_level=1.0,
+def generate_plates_simulation(seed, width, height, ocean_level=0.65,
                                erosion_period=60, folding_ratio=0.02,
                                aggr_overlap_abs=1000000, aggr_overlap_rel=0.33,
                                cycle_count=2, num_plates=10,
@@ -36,7 +36,7 @@ def generate_plates_simulation(seed, width, height, ocean_level=1.0,
 
 
 def _plates_simulation(name, width, height, seed, num_plates=10,
-                       ocean_level=1.0, step=Step.full(),
+                       ocean_level=0.65, step=Step.full(),
                        verbose=get_verbose()):
     e_as_array, p_as_array = generate_plates_simulation(seed, width, height,
                                                         ocean_level=ocean_level,
@@ -49,7 +49,7 @@ def _plates_simulation(name, width, height, seed, num_plates=10,
     return world
 
 
-def world_gen(name, width, height, seed, num_plates=10, ocean_level=1.0,
+def world_gen(name, width, height, seed, num_plates=10, ocean_level=0.65,
               step=Step.full(), verbose=get_verbose()):
     if verbose:
         start_time = time.time()

--- a/worldengine/simulations/basic.py
+++ b/worldengine/simulations/basic.py
@@ -41,7 +41,7 @@ def find_threshold(elevation, land_percentage, ocean=None):
     return search(0, 255, desired_land)
 
 
-def find_threshold_f(elevation, land_perc, ocean=None):
+def find_threshold_f(elevation, land_perc, ocean=None, max=1000.0, mindist=0.005):
     width = len(elevation[0])
     height = len(elevation)
     if ocean:
@@ -62,7 +62,7 @@ def find_threshold_f(elevation, land_perc, ocean=None):
     def search(a, b, desired):
         if a == b:
             return a
-        if abs(b - a) < 0.005:
+        if abs(b - a) < mindist:
             ca = count(a)
             cb = count(b)
             dista = abs(desired - ca)
@@ -85,4 +85,4 @@ def find_threshold_f(elevation, land_perc, ocean=None):
                 if ocean[y][x]:
                     all_land -= 1
     desired_land = all_land * land_perc
-    return search(-1000.0, 1000.0, desired_land)
+    return search(-1*max, max, desired_land)


### PR DESCRIPTION
I took a look into the problem of the inability to create oceans with differing depths.
According to the following comment from https://github.com/Mindwerks/plate-tectonics/blob/master/src/lithosphere.cpp
    // Find the actual value in height map that produces the continent-sea ratio defined be "sea_level".

I assume that said sea_level is indeed what is responsible for the depth of the ocean and hence isomorphic to the variable ocean_level used in https://github.com/Mindwerks/worldengine/blob/master/worldengine/plates.py

That variable, however, was not passed to generate_plates_simulation() and thus not to platec (line 42 of the commit).

I am still unable to run the worldengines source-code, therefore I cannot guarantee that this fixes the problem described here:
https://github.com/Mindwerks/worldengine/issues/114
https://github.com/Mindwerks/worldengine/issues/116

At the very least this looks like a sensible change and one that is simple enough to not cause problems.

This is my very first pull request. Feedback on its style is appreciated.