### PR TITLE
Seed fix

### DIFF
--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -389,7 +389,7 @@ def main():
             usage("The specified world file does not exist")
 
     random.seed()
-    if args.seed:
+    if args.seed is not None:
         seed = int(args.seed)
     else:
         seed = random.randint(0, 65536)

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -392,7 +392,7 @@ def main():
     if args.seed is not None:
         seed = int(args.seed)
     else:
-        seed = random.randint(0, 65536)
+        seed = random.randint(0, 65535)
     if args.world_name:
         world_name = args.world_name
     else:

--- a/worldengine/simulations/biome.py
+++ b/worldengine/simulations/biome.py
@@ -7,7 +7,7 @@ class BiomeSimulation(object):
 
     @staticmethod
     def execute(world, seed):
-        assert seed
+        assert seed is None
         w = world
         width = world.width
         height = world.height

--- a/worldengine/simulations/biome.py
+++ b/worldengine/simulations/biome.py
@@ -7,7 +7,7 @@ class BiomeSimulation(object):
 
     @staticmethod
     def execute(world, seed):
-        assert seed is None
+        assert seed is not None
         w = world
         width = world.width
         height = world.height

--- a/worldengine/simulations/humidity.py
+++ b/worldengine/simulations/humidity.py
@@ -8,7 +8,7 @@ class HumiditySimulation(object):
             not world.has_humidity())
 
     def execute(self, world, seed):
-        assert seed
+        assert seed is None
         world.humidity = self._calculate(world)
 
     @staticmethod

--- a/worldengine/simulations/humidity.py
+++ b/worldengine/simulations/humidity.py
@@ -8,7 +8,7 @@ class HumiditySimulation(object):
             not world.has_humidity())
 
     def execute(self, world, seed):
-        assert seed is None
+        assert seed is not None
         world.humidity = self._calculate(world)
 
     @staticmethod

--- a/worldengine/simulations/hydrology.py
+++ b/worldengine/simulations/hydrology.py
@@ -8,7 +8,7 @@ class WatermapSimulation(object):
         return world.has_precipitations() and (not world.has_watermap())
 
     def execute(self, world, seed):
-        assert seed
+        assert seed is None
         world.watermap = self._watermap(world, 20000)
 
     @staticmethod

--- a/worldengine/simulations/hydrology.py
+++ b/worldengine/simulations/hydrology.py
@@ -8,7 +8,7 @@ class WatermapSimulation(object):
         return world.has_precipitations() and (not world.has_watermap())
 
     def execute(self, world, seed):
-        assert seed is None
+        assert seed is not None
         world.watermap = self._watermap(world, 20000)
 
     @staticmethod


### PR DESCRIPTION
A very small change. I found it very confusing that the parameter "seed=0" resulted in a random seed even though internally 0 is a perfectly valid seed value. Since negative parameters should be equally valid anyway, only cutting out 0 seemed like an oversight.

Also, I changed 65536 to 65535. randint() includes its boundaries, so the former number results in a range of 2^16+1 (and it really looked like it was meant to be 2^16). Extremely minor and unimportant, I guess. But I was already changing the code anyway...