### PR TITLE
The random generator now properly uses the seed to produce deterministic results.

### DIFF
--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -391,8 +391,7 @@ def main():
     if args.seed is not None:
         seed = int(args.seed)
     else:
-        random.seed()
-        seed = random.randint(0, 65535)
+        seed = random.randint(0, 65535)#RNG initialization is done automatically
     random.seed(seed)
 
     if args.world_name:

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -388,11 +388,13 @@ def main():
         if not os.path.exists(args.FILE):
             usage("The specified world file does not exist")
 
-    random.seed()
     if args.seed is not None:
         seed = int(args.seed)
     else:
+        random.seed()
         seed = random.randint(0, 65535)
+    random.seed(seed)
+
     if args.world_name:
         world_name = args.world_name
     else:


### PR DESCRIPTION
I am not sure what the wanted behaviour is, but this looked like it might be unintentional. Since the seed wasn't used to seed the random generator, successive calls to random() of any kind (which occur at several points in the code) gave actual random results, even when a seed was given.

This patch makes the seed be the actual seed of the random generator. This got rid of some of the problems I was having when trying to modify the ocean_level variable so that it can actually modify the ocean level. That is not done yet, however.

It also got rid of the remaining lack of deterministicness I saw when regenerating a world with the same seed (there were some slight changes in colors...hopefully weren't my eyes).

If this proves useful, the seed-variable could probably be removed as a parameter from several function calls. In theory it should not be needed anywhere after having set off the RNG.