### PR TITLE
Changed paths for grayscale- and rivers-map.

### DIFF
--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -449,9 +449,11 @@ def main():
                                step, args.ocean_level, world_format,
                                args.verbose, black_and_white=args.black_and_white)
         if args.grayscale_heightmap:
-            generate_grayscale_heightmap(world, world_name+"_grayscale.png")
+            generate_grayscale_heightmap(world,
+            '%s/%s_grayscale.png' % (args.output_dir, world_name))
         if args.rivers_map:
-            generate_rivers_map(world, world_name+"_rivers.png")
+            generate_rivers_map(world,
+            '%s/%s_rivers.png' % (args.output_dir, world_name))
 
     elif operation == 'plates':
         print('')  # empty line


### PR DESCRIPTION
Since the actual filenames of grayscale- and rivers-map follow the same pattern as all the other maps, I found it annoying that the generated maps aren't just all placed in the same directory. Kind of makes it difficult to (auto-)generate several maps at once (I wrote a script to generate half a dozen decently sized maps while I'm away and the files being spread around doesn't feel right).

This might seem a bit dirty, there may be other filenames I overlooked. But somebody else shall look at it and decide if the commit is useful or needs some polish.

EDIT: I won the coveralls-lottery.^^