### PR TITLE
random.seed()

### DIFF
--- a/tests/basic_map_operations_test.py
+++ b/tests/basic_map_operations_test.py
@@ -9,14 +9,13 @@ class TestBasicMapOperations(unittest.TestCase):
         pass
 
     def test_random_point(self):
-        for seed in [0, 1, 27, 29, 1939, 1982, 2015]:
-            random.seed(seed)
-            for n in range(10):
-                x, y = random_point(100, 200)
-                self.assertTrue(x >= 0,  "x is within boundaries")
-                self.assertTrue(x < 100, "x is within boundaries")
-                self.assertTrue(y >= 0,  "y is within boundaries")
-                self.assertTrue(y < 200, "y is within boundaries")
+        random.seed(0)
+        for n in range(100):
+            x, y = random_point(100, 200)
+            self.assertTrue(x >= 0,  "x is within boundaries")
+            self.assertTrue(x < 100, "x is within boundaries")
+            self.assertTrue(y >= 0,  "y is within boundaries")
+            self.assertTrue(y < 200, "y is within boundaries")
 
     def test_distance(self):
         self.assertAlmostEquals(22.360679774997898, distance((0, 0), (10, 20)))

--- a/worldengine/drawing_functions.py
+++ b/worldengine/drawing_functions.py
@@ -602,7 +602,6 @@ def draw_ancientmap(world, target, resize_factor=1,
                     sea_color=(212, 198, 169, 255),
                     draw_biome = True, draw_rivers = True, draw_mountains = True,
                     draw_outer_land_border = False, verbose=get_verbose()):
-    random.seed(world.seed * 11)  
 
     if verbose:
         start_time = time.time()

--- a/worldengine/simulations/permeability.py
+++ b/worldengine/simulations/permeability.py
@@ -19,7 +19,6 @@ class PermeabilitySimulation(object):
 
     @staticmethod
     def _calculate(seed, width, height):
-        random.seed(seed * 37)
         base = random.randint(0, 4096)
         perm = [[0 for x in range(width)] for y in range(height)]  # TODO: replace with numpy
 

--- a/worldengine/simulations/precipitation.py
+++ b/worldengine/simulations/precipitation.py
@@ -32,7 +32,6 @@ class PrecipitationSimulation(object):
     def _calculate(seed, width, height):
         """Precipitation is a value in [-1,1]"""
         border = width / 4
-        random.seed(seed * 13)
         base = random.randint(0, 4096)
         precipitations = [[0 for x in range(width)] for y in range(height)]
         # TODO: replace with numpy

--- a/worldengine/simulations/temperature.py
+++ b/worldengine/simulations/temperature.py
@@ -30,7 +30,6 @@ class TemperatureSimulation(object):
         width = world.width
         height = world.height
 
-        random.seed(seed * 7)
         base = random.randint(0, 4096)
         temp = [[0 for x in range(width)] for y in range(height)]  # TODO: replace with numpy
 


### PR DESCRIPTION
I noticed that several calls to the seed()-function are spread all over different files. This changes the seed for every part of the program that comes afterwards.

Either seed() should be called exactly once per program (as done in main() ) *or* if a change of seeds is really necessary, the seed should be reset to its original value after the current function finishes.
E.g.:
```python
def a(seed):
    random.seed(seed*5)
    importantnumber=random.randint(0, 4096)
    random.seed(seed) #reset
```

I think the first approach is the cleanest and best, though. Python uses a Mersenne Twister for its random number generation, and when it comes to pseudo-random numbers that is about as good as it gets.

Two notes on this:
1. Should this commit be merged, results of generated worlds (*permeability, precipitation, temperature*) will change (since the files in question now use a different seed). I guess that blessed images would have to be regenerated and every saved world out there would change.

2. I noticed calls to seed() in the tests. I guess it would be best if random.seed() was called exactly once during the tests, but I don't know if the tests are run as separate programs (each of which would have to initiate the RNG) or if they all share the same RNG. Any idea?

3. Is there any combination of parameters that could allow worldengine to bypass the call to random.seed() in the main() function? If so, the RNG should be initiated earlier than that to make sure that a passed seed is actually made use of.