### PR TITLE
Modification to the routines for drawing colored elevation maps.

### DIFF
--- a/tests/blessed_images/generated_blessed_images.py
+++ b/tests/blessed_images/generated_blessed_images.py
@@ -15,8 +15,8 @@ from worldengine.draw import *
 
 def main(blessed_images_dir, tests_data_dir):
     w = World.open_protobuf("%s/seed_28070.world" % tests_data_dir)
-    draw_simple_elevation_on_file(w, "%s/simple_elevation_28070.png"
-                                  % blessed_images_dir, w.sea_level())
+    draw_simple_elevation_on_file(w.elevation['data'], "%s/simple_elevation_28070.png"
+                                  % blessed_images_dir, w.width, w.height, w.sea_level())
     draw_elevation_on_file(w, "%s/elevation_28070_shadow.png" % blessed_images_dir, shadow=True)
     draw_elevation_on_file(w, "%s/elevation_28070_no_shadow.png" % blessed_images_dir, shadow=False)
     draw_riversmap_on_file(w, "%s/riversmap_28070.png" % blessed_images_dir)

--- a/tests/blessed_images/generated_blessed_images.py
+++ b/tests/blessed_images/generated_blessed_images.py
@@ -15,8 +15,8 @@ from worldengine.draw import *
 
 def main(blessed_images_dir, tests_data_dir):
     w = World.open_protobuf("%s/seed_28070.world" % tests_data_dir)
-    draw_simple_elevation_on_file(w.elevation['data'], "%s/simple_elevation_28070.png"
-                                  % blessed_images_dir, w.width, w.height, w.sea_level())
+    draw_simple_elevation_on_file(w, "%s/simple_elevation_28070.png"
+                                  % blessed_images_dir, w.sea_level())
     draw_elevation_on_file(w, "%s/elevation_28070_shadow.png" % blessed_images_dir, shadow=True)
     draw_elevation_on_file(w, "%s/elevation_28070_no_shadow.png" % blessed_images_dir, shadow=False)
     draw_riversmap_on_file(w, "%s/riversmap_28070.png" % blessed_images_dir)

--- a/tests/draw_test.py
+++ b/tests/draw_test.py
@@ -102,9 +102,8 @@ class TestDraw(TestBase):
 
     def test_draw_simple_elevation(self):
         w = World.open_protobuf("%s/seed_28070.world" % self.tests_data_dir)
-        data = w.elevation['data']
         target = PixelCollector(w.width, w.height)
-        draw_simple_elevation(data, w.width, w.height, w.sea_level(), target)
+        draw_simple_elevation(w, w.sea_level(), target)
         self._assert_img_equal("simple_elevation_28070", target)
 
     def test_draw_elevation_shadow(self):

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -103,13 +103,11 @@ def generate_plates(seed, world_name, output_dir, width, height,
     filename = '%s/plates_%s.png' % (output_dir, world_name)
     # TODO calculate appropriate sea_level
     sea_level = 1.0
-    draw_simple_elevation_on_file(world.elevation['data'], filename, width,
-                                  height, sea_level)
+    draw_simple_elevation_on_file(world, filename, sea_level)
     print("+ plates image generated in '%s'" % filename)
     geo.center_land(world)
     filename = '%s/centered_plates_%s.png' % (output_dir, world_name)
-    draw_simple_elevation_on_file(world.elevation['data'], filename, width,
-                                  height, sea_level)
+    draw_simple_elevation_on_file(world, filename, sea_level)
     print("+ centered plates image generated in '%s'" % filename)
 
 

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -103,11 +103,11 @@ def generate_plates(seed, world_name, output_dir, width, height,
     filename = '%s/plates_%s.png' % (output_dir, world_name)
     # TODO calculate appropriate sea_level
     sea_level = 1.0
-    draw_simple_elevation_on_file(world, filename, sea_level)
+    draw_simple_elevation_on_file(world, filename, -1)
     print("+ plates image generated in '%s'" % filename)
     geo.center_land(world)
     filename = '%s/centered_plates_%s.png' % (output_dir, world_name)
-    draw_simple_elevation_on_file(world, filename, sea_level)
+    draw_simple_elevation_on_file(world, filename, -1)
     print("+ centered plates image generated in '%s'" % filename)
 
 

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -103,11 +103,11 @@ def generate_plates(seed, world_name, output_dir, width, height,
     filename = '%s/plates_%s.png' % (output_dir, world_name)
     # TODO calculate appropriate sea_level
     sea_level = 1.0
-    draw_simple_elevation_on_file(world, filename, -1)
+    draw_simple_elevation_on_file(world, filename, None)
     print("+ plates image generated in '%s'" % filename)
     geo.center_land(world)
     filename = '%s/centered_plates_%s.png' % (output_dir, world_name)
-    draw_simple_elevation_on_file(world, filename, -1)
+    draw_simple_elevation_on_file(world, filename, None)
     print("+ centered plates image generated in '%s'" % filename)
 
 

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -64,8 +64,7 @@ def generate_world(world_name, width, height, seed, num_plates, output_dir,
 
     filename = '%s/%s_elevation.png' % (output_dir, world_name)
     sea_level = w.sea_level()
-    draw_simple_elevation_on_file(w.elevation['data'], filename, width=width,
-                                  height=height, sea_level=sea_level)
+    draw_simple_elevation_on_file(w, filename, sea_level=sea_level)
     print("* elevation image generated in '%s'" % filename)
     return w
 

--- a/worldengine/draw.py
+++ b/worldengine/draw.py
@@ -64,6 +64,8 @@ def _elevation_color(elevation, sea_level=1.0):
     :return:
     """
     color_step = 1.5
+    if sea_level is None:
+        sea_level = -1
     if elevation < sea_level/2:
         elevation /= sea_level
         return 0.0, 0.0, 0.75 + 0.5 * elevation
@@ -172,7 +174,7 @@ def draw_simple_elevation(world, sea_level, target):
     for y in range(world.height):
         for x in range(world.width):
             e = world.elevation['data'][y,x]
-            if sea_level == -1:
+            if sea_level is None:
                 if min_elev_land is None or e < min_elev_land:
                     min_elev_land = e
                 if max_elev_land is None or e > max_elev_land:
@@ -189,13 +191,13 @@ def draw_simple_elevation(world, sea_level, target):
                     max_elev_sea = e
 
     elev_delta_land = (max_elev_land - min_elev_land)/11
-    if sea_level != -1:
+    if sea_level != None:
         elev_delta_sea = max_elev_sea - min_elev_sea
     
     for y in range(world.height):
         for x in range(world.width):
             e = world.elevation['data'][y, x]
-            if sea_level == -1:
+            if sea_level is None:
                 c = ((e - min_elev_land) / elev_delta_land) + 1
             elif world.is_land((x, y)):
                 c = ((e - min_elev_land) / elev_delta_land) + 1

--- a/worldengine/draw.py
+++ b/worldengine/draw.py
@@ -172,7 +172,12 @@ def draw_simple_elevation(world, sea_level, target):
     for y in range(world.height):
         for x in range(world.width):
             e = world.elevation['data'][y,x]
-            if world.is_land((x, y)):
+            if sea_level == -1:
+                if min_elev_land is None or e < min_elev_land:
+                    min_elev_land = e
+                if max_elev_land is None or e > max_elev_land:
+                    max_elev_land = e
+            elif world.is_land((x, y)):
                 if min_elev_land is None or e < min_elev_land:
                     min_elev_land = e
                 if max_elev_land is None or e > max_elev_land:
@@ -184,12 +189,15 @@ def draw_simple_elevation(world, sea_level, target):
                     max_elev_sea = e
 
     elev_delta_land = (max_elev_land - min_elev_land)/11
-    elev_delta_sea = max_elev_sea - min_elev_sea
+    if sea_level != -1:
+        elev_delta_sea = max_elev_sea - min_elev_sea
     
     for y in range(world.height):
         for x in range(world.width):
             e = world.elevation['data'][y, x]
-            if world.is_land((x, y)):
+            if sea_level == -1:
+                c = ((e - min_elev_land) / elev_delta_land) + 1
+            elif world.is_land((x, y)):
                 c = ((e - min_elev_land) / elev_delta_land) + 1
             else:
                 c = ((e - min_elev_sea) / elev_delta_sea)


### PR DESCRIPTION
This raises the minimum altitude of the land to sea level and then normalizes the elevation values to the range of 1 to 12 for the colored elevation map. This prevents the need of repeating color bands to represent higher ranges. As elevation has no inherent value the normalization causes no real distortions. The raising of the minimum land value means there is no land with an altitude above sea level (something which can occur in the real world) but it makes the elevation map easier to import into other programs such as Fractal Terrains and such a solution is already used in the grayscale height maps.

This modification will affect the output of the colored elevation map to an extent where any blessed images of elevation maps will need to be recalculated.