### PR TITLE
Temperature and Humidity parameters can be altered from the command line.

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -54,7 +54,9 @@ class TestCLI(TestBase):
         # everything without it exploding?
         backup_argv = sys.argv
         sys.argv = ["python", "--width", "16", "--height", "16",
-                    "-r", "--gs"]
+                    "-r", "-v", "--gs", "--temps",
+                    ".126/.235/.406/.561/.634/.876", "--humidity",
+                    ".059/.222/.493/.764/.927/.986/.998"]
         try:
             main()
         except Exception as e:

--- a/tests/generation_test.py
+++ b/tests/generation_test.py
@@ -14,7 +14,7 @@ class TestGeneration(TestBase):
     def test_world_gen_does_not_explode_badly(self):
         # FIXME remove me when proper tests are in place
         # Very stupid test that just verify nothing explode badly
-        world_gen("Dummy", 32, 16, 1, step=Step.get_by_name("full"))
+        world_gen("Dummy", 32, 16, 1, [.874, .765, .594, .439, .366, .124], [.941, .778, .507, .236, 0.073, .014, .002], step=Step.get_by_name("full"))
 
     @staticmethod
     def _mean_elevation_at_borders(world):

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -11,7 +11,7 @@ class TestSerialization(unittest.TestCase):
         self.maxDiff = None
 
     def test_pickle_serialize_unserialize(self):
-        w = world_gen("Dummy", 32, 16, 1, step=Step.get_by_name("full"))
+        w = world_gen("Dummy", 32, 16, 1, [.874, .765, .594, .439, .366, .124], [.941, .778, .507, .236, 0.073, .014, .002], step=Step.get_by_name("full"))
         f = tempfile.NamedTemporaryFile(delete=False).name
         w.to_pickle_file(f)
         unserialized = World.from_pickle_file(f)
@@ -37,7 +37,7 @@ class TestSerialization(unittest.TestCase):
         self.assertEqual(w, unserialized)
 
     def test_protobuf_serialize_unserialize(self):
-        w = world_gen("Dummy", 32, 16, 1, step=Step.get_by_name("full"))
+        w = world_gen("Dummy", 32, 16, 1, [.874, .765, .594, .439, .366, .124], [.941, .778, .507, .236, 0.073, .014, .002], step=Step.get_by_name("full"))
         serialized = w.protobuf_serialize()
         unserialized = World.protobuf_unserialize(serialized)
         self.assertTrue(_equal(w.elevation['data'], unserialized.elevation['data']))

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -302,12 +302,12 @@ def main():
     g_generate.add_argument('--temps', dest='temps', 
                         help="Provide alternate ranges for temperatures. " +
                              "If not provided, the default values will be used. \n" +
-                             "[default = 0.874/0.765/0.594/0.439/0.366/0.124]",
+                             "[default = .126/.235/.406/.561/.634/.876]",
                             metavar="#/#/#/#/#/#")
     g_generate.add_argument('--humidity', dest='humids', 
                         help="Provide alternate ranges for humidities. " +
                              "If not provided, the default values will be used. \n" +
-                            "[default = .941/.778/.507/.236/.073/.014/.002]",
+                            "[default = .059/.222/.493/.764/.927/.986/.998]",
                             metavar="#/#/#/#/#/#/#")
     g_generate.add_argument('--not-fade-borders', dest='fade_borders', action="store_false",
                                help="Not fade borders",
@@ -439,7 +439,7 @@ def main():
     if args.temps:
         temps = args.temps.split('/')
         for x in range(0,6):
-            temps[x] = float(temps[x])
+            temps[x] = 1 - float(temps[x])
 
     if args.humids and not generation_operation:
         usage(error="humidity can be assigned only during world generation")
@@ -451,7 +451,7 @@ def main():
     if args.humids:
         humids = args.humids.split('/')
         for x in range(0,7):
-            humids[x] = float(humids[x])
+            humids[x] = 1 - float(humids[x])
 
     print('Worldengine - a world generator (v. %s)' % VERSION)
     print('-----------------------')
@@ -469,9 +469,9 @@ def main():
         print(' rivers map           : %s' % args.rivers_map)
         print(' fade borders         : %s' % args.fade_borders)
     if args.temps:
-        print(' temperature ranges   : %s' % temps)
+        print(' temperature ranges   : %s' % args.temps)
     if args.humids:
-        print(' humidity ranges      : %s' % humids)
+        print(' humidity ranges      : %s' % args.humids)
     if operation == 'ancient_map':
         print(' resize factor          : %i' % args.resize_factor)
         print(' world file             : %s' % args.world_file)

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -23,9 +23,10 @@ STEPS = 'plates|precipitations|full'
 
 
 def generate_world(world_name, width, height, seed, num_plates, output_dir,
-                   step, ocean_level, world_format='pickle', fade_borders=True,
+                   step, ocean_level, temps, humids,
+                   world_format='pickle', fade_borders=True,
                    verbose=True, black_and_white=False):
-    w = world_gen(world_name, width, height, seed, num_plates, ocean_level,
+    w = world_gen(world_name, width, height, seed, temps, humids, num_plates, ocean_level,
                   step, fade_borders=fade_borders, verbose=verbose)
 
     print('')  # empty line
@@ -299,6 +300,16 @@ def main():
                             help='elevation cut off for sea level " +'
                                  '[default = %(default)s]',
                             metavar="N", default=1.0)
+    g_generate.add_argument('--temps', dest='temps', 
+                        help="Provide alternate ranges for temperatures. " +
+                             "If not provided, the default values will be used. \n" +
+                             "[default = 0.874/0.765/0.594/0.439/0.366/0.124]",
+                            metavar="#/#/#/#/#/#")
+    g_generate.add_argument('--humidity', dest='humids', 
+                        help="Provide alternate ranges for humidities. " +
+                             "If not provided, the default values will be used. \n" +
+                            "[default = .941/.778/.507/.236/.073/.014/.002]",
+                            metavar="#/#/#/#/#/#/#")
     g_generate.add_argument('--not-fade-borders', dest='fade_borders', action="store_false",
                                help="Not fade borders",
                                default=True)
@@ -417,6 +428,30 @@ def main():
     if args.rivers_map and not generation_operation:
         usage(error="Rivers map can be produced only during world generation")
 
+    if args.temps and not generation_operation:
+        usage(error="temps can be assigned only during world generation")
+
+    if args.temps and len(args.temps.split('/')) is not 6:
+        usage(error="temps must have exactly 6 values")
+
+    temps =[.874, .765, .594, .439, .366, .124]
+    if args.temps:
+        temps = args.temps.split('/')
+        for x in range(0,6):
+            temps[x] = float(temps[x])
+
+    if args.humids and not generation_operation:
+        usage(error="humidity can be assigned only during world generation")
+
+    if args.humids and len(args.humids.split('/')) is not 7:
+        usage(error="humidity must have exactly 7 values")
+
+    humids = [.941, .778, .507, .236, 0.073, .014, .002]
+    if args.humids:
+        humids = args.humids.split('/')
+        for x in range(0,7):
+            humids[x] = float(humids[x])
+
     print('Worldengine - a world generator (v. %s)' % VERSION)
     print('-----------------------')
     print(' operation         : %s generation' % operation)
@@ -432,6 +467,10 @@ def main():
         print(' greyscale heightmap  : %s' % args.grayscale_heightmap)
         print(' rivers map           : %s' % args.rivers_map)
         print(' fade borders         : %s' % args.fade_borders)
+    if args.temps:
+        print(' temperature ranges   : %s' % temps)
+    if args.humids:
+        print(' humidity ranges      : %s' % humids)
     if operation == 'ancient_map':
         print(' resize factor          : %i' % args.resize_factor)
         print(' world file             : %s' % args.world_file)
@@ -449,7 +488,7 @@ def main():
 
         world = generate_world(world_name, args.width, args.height,
                                seed, args.number_of_plates, args.output_dir,
-                               step, args.ocean_level, world_format,
+                               step, args.ocean_level, temps, humids, world_format,
                                fade_borders=args.fade_borders,
                                verbose=args.verbose, black_and_white=args.black_and_white)
         if args.grayscale_heightmap:

--- a/worldengine/plates.py
+++ b/worldengine/plates.py
@@ -36,24 +36,24 @@ def generate_plates_simulation(seed, width, height, sea_level=0.65,
     return hm, pm
 
 
-def _plates_simulation(name, width, height, seed, num_plates=10,
+def _plates_simulation(name, width, height, seed, temps, humids, num_plates=10,
                        ocean_level=1.0, step=Step.full(),
                        verbose=get_verbose()):
     e_as_array, p_as_array = generate_plates_simulation(seed, width, height,
                                                         num_plates=num_plates,
                                                         verbose=verbose)
 
-    world = World(name, width, height, seed, num_plates, ocean_level, step)
+    world = World(name, width, height, seed, num_plates, ocean_level, step, temps, humids)
     world.set_elevation(numpy.array(e_as_array).reshape(height, width), None)
     world.set_plates(array_to_matrix(p_as_array, width, height))
     return world
 
 
-def world_gen(name, width, height, seed, num_plates=10, ocean_level=1.0,
+def world_gen(name, width, height, seed, temps, humids, num_plates=10, ocean_level=1.0,
               step=Step.full(), fade_borders=True, verbose=get_verbose()):
     if verbose:
         start_time = time.time()
-    world = _plates_simulation(name, width, height, seed, num_plates,
+    world = _plates_simulation(name, width, height, seed, temps, humids, num_plates,
                                ocean_level, step, verbose)
 
     center_land(world)

--- a/worldengine/simulations/humidity.py
+++ b/worldengine/simulations/humidity.py
@@ -14,6 +14,7 @@ class HumiditySimulation(object):
 
     @staticmethod
     def _calculate(world):
+        humids = world.humids
         humidity = dict()
         temperatureWeight = 2.3
         precipitationWeight = 1.0
@@ -25,18 +26,18 @@ class HumiditySimulation(object):
         # These were originally evenly spaced at 12.5% each but changing them
         # to a bell curve produced better results
         humidity['quantiles'] = {}
-        humidity['quantiles']['12'] = find_threshold_f(humidity['data'], 0.002,
+        humidity['quantiles']['12'] = find_threshold_f(humidity['data'], humids[6],
                                                        world.ocean)
-        humidity['quantiles']['25'] = find_threshold_f(humidity['data'], 0.014,
+        humidity['quantiles']['25'] = find_threshold_f(humidity['data'], humids[5],
                                                        world.ocean)
-        humidity['quantiles']['37'] = find_threshold_f(humidity['data'], 0.073,
+        humidity['quantiles']['37'] = find_threshold_f(humidity['data'], humids[4],
                                                        world.ocean)
-        humidity['quantiles']['50'] = find_threshold_f(humidity['data'], 0.236,
+        humidity['quantiles']['50'] = find_threshold_f(humidity['data'], humids[3],
                                                        world.ocean)
-        humidity['quantiles']['62'] = find_threshold_f(humidity['data'], 0.507,
+        humidity['quantiles']['62'] = find_threshold_f(humidity['data'], humids[2],
                                                        world.ocean)
-        humidity['quantiles']['75'] = find_threshold_f(humidity['data'], 0.778,
+        humidity['quantiles']['75'] = find_threshold_f(humidity['data'], humids[1],
                                                        world.ocean)
-        humidity['quantiles']['87'] = find_threshold_f(humidity['data'], 0.941,
+        humidity['quantiles']['87'] = find_threshold_f(humidity['data'], humids[0],
                                                        world.ocean)
         return humidity

--- a/worldengine/simulations/temperature.py
+++ b/worldengine/simulations/temperature.py
@@ -16,12 +16,12 @@ class TemperatureSimulation(object):
 
         t = self._calculate(world, seed, e, ml)
         t_th = [
-            ('polar', find_threshold_f(t, 0.874, ocean)),
-            ('alpine', find_threshold_f(t, 0.765, ocean)),
-            ('boreal', find_threshold_f(t, 0.594, ocean)),
-            ('cool', find_threshold_f(t, 0.439, ocean)),
-            ('warm', find_threshold_f(t, 0.366, ocean)),
-            ('subtropical', find_threshold_f(t, 0.124, ocean)),
+            ('polar', find_threshold_f(t, world.temps[0], ocean)),
+            ('alpine', find_threshold_f(t, world.temps[1], ocean)),
+            ('boreal', find_threshold_f(t, world.temps[2], ocean)),
+            ('cool', find_threshold_f(t, world.temps[3], ocean)),
+            ('warm', find_threshold_f(t, world.temps[4], ocean)),
+            ('subtropical', find_threshold_f(t, world.temps[5], ocean)),
             ('tropical', None)
         ]
         world.set_temperature(t, t_th)

--- a/worldengine/world.py
+++ b/worldengine/world.py
@@ -24,7 +24,8 @@ class World(object):
     """
 
     def __init__(self, name, width, height, seed, num_plates, ocean_level,
-                 step):
+                 step, temps=[0.874, 0.765, 0.594, 0.439, 0.366, 0.124],
+                 humids = [.941, .778, .507, .236, 0.073, .014, .002]):
         self.name = name
         self.width = width
         self.height = height
@@ -32,6 +33,8 @@ class World(object):
         self.n_plates = num_plates
         self.ocean_level = ocean_level
         self.step = step
+        self.temps = temps
+        self.humids = humids
 
     #
     # General methods


### PR DESCRIPTION
Added command line options for Temperature and Humidity ranges. While this does not fully allow the creation of non-terrestrial planets (we need to be able to alter how much water there is) it brings us much further along.

$ python worldengine -b -s 1 --temps 1/1/1/1/0.594/0.439  --humidity .507/.236/.073/.014/.002/.0/.0
Worldengine - a world generator (v. 0.18.0)
-----------------------
 operation         : world generation
 seed                 : 1
 name                 : seed_1
 width                : 512
 height               : 512
 number of plates     : 10
 world format         : protobuf
 black and white maps : False
 step                 : full
 greyscale heightmap  : False
 rivers map           : False
 fade borders         : True
 temperature ranges   : [1.0, 1.0, 1.0, 1.0, 0.594, 0.439]
 humidity ranges      : [0.507, 0.236, 0.073, 0.014, 0.002, 0.0, 0.0]

starting (it could take a few minutes) ...

Producing ouput:
* world data saved in './seed_1.world'
* ocean image generated in './seed_1_ocean.png'
* precipitation image generated in './seed_1_precipitation.png'
* temperature image generated in './seed_1_temperature.png'
* biome image generated in './seed_1_biome.png'
* elevation image generated in './seed_1_elevation.png'
...done

![ancient_map_seed_1](https://cloud.githubusercontent.com/assets/8743461/10839958/f8e04710-7e96-11e5-9fa4-30418f213633.png)
