### PR TITLE
Fix link to worldengine-gui project

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For Windows, Linux and Mac are available on the [releases page](https://github.c
 Gui
 ===
 
-An experimental (and limited!) GUI is available as a separate project: [https://github.com/Mindwerks/worldengine-gui](worldengine-gui).
+An experimental (and limited!) GUI is available as a separate project: [https://github.com/Mindwerks/worldengine-gui](https://github.com/Mindwerks/worldengine-gui).
 
 Install
 =======


### PR DESCRIPTION
This PR fixes the link to the GUI project on the README file.