### PR TITLE
Satellite map

### DIFF
--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -7,7 +7,7 @@ import worldengine.generation as geo
 from worldengine.common import array_to_matrix, set_verbose, print_verbose
 from worldengine.draw import draw_ancientmap_on_file, draw_biome_on_file, draw_ocean_on_file, \
     draw_precipitation_on_file, draw_grayscale_heightmap_on_file, draw_simple_elevation_on_file, \
-    draw_temperature_levels_on_file, draw_riversmap_on_file, draw_scatter_plot_on_file
+    draw_temperature_levels_on_file, draw_riversmap_on_file, draw_scatter_plot_on_file, draw_satellite_on_file
 from worldengine.plates import world_gen, generate_plates_simulation
 from worldengine.imex import export
 from worldengine.step import Step
@@ -82,6 +82,9 @@ def draw_scatter_plot(world, filename):
     draw_scatter_plot_on_file(world, filename)
     print("+ scatter plot generated in '%s'" % filename)
 
+def draw_satellite_map(world, filename):
+    draw_satellite_on_file(world, filename)
+    print("+ satellite map generated in '%s'" % filename)
 
 def generate_plates(seed, world_name, output_dir, width, height,
                     num_plates=10):
@@ -317,6 +320,9 @@ def main():
     g_generate.add_argument('--scatter', dest='scatter_plot',
                             action="store_true", help="generate scatter plot")
 
+    g_generate.add_argument('--sat', dest='satelite_map',
+                            action="store_true", help="generate satellite map")
+
     # -----------------------------------------------------
     g_ancient_map = parser.add_argument_group(
         "Ancient Map Options", "These options are only useful in " +
@@ -469,6 +475,7 @@ def main():
         print(' greyscale heightmap  : %s' % args.grayscale_heightmap)
         print(' rivers map           : %s' % args.rivers_map)
         print(' scatter plot         : %s' % args.scatter_plot)
+        print(' satellite map        : %s' % args.satelite_map)
         print(' fade borders         : %s' % args.fade_borders)
     if args.temps:
         print(' temperature ranges   : %s' % args.temps)
@@ -503,6 +510,10 @@ def main():
         if args.scatter_plot:
             draw_scatter_plot(world,
             '%s/%s_scatter.png' % (args.output_dir, world_name))    
+        if args.satelite_map:
+            draw_satellite_map(world,
+            '%s/%s_satellite.png' % (args.output_dir, world_name))    
+
 
     elif operation == 'plates':
         print('')  # empty line

--- a/worldengine/draw.py
+++ b/worldengine/draw.py
@@ -1,6 +1,7 @@
 from PIL import Image
 import numpy
 import numpy.ma as ma
+import random
 
 from worldengine.drawing_functions import draw_ancientmap, \
     draw_rivers_on_image

--- a/worldengine/draw.py
+++ b/worldengine/draw.py
@@ -313,16 +313,22 @@ def draw_satellite(world, target):
 
     noise_range = 10 # a random value between -noise_range and noise_range will be added to the rgb of each pixel
 
+    # These are arbitrarily-chosen elevation cutoffs for 4 different height levels. 
+    # Some color modifiers will be applied at each level
     high_mountain_elev = 215
     mountain_elev      = 175
     high_hill_elev     = 160
     hill_elev          = 145
 
+    # These are rgb color values which will be added to the noise, if the elevation is greater than the height specified
+    # These are not cumulative
     high_mountain_noise_modifier = (10, 6,   10)
     mountain_noise_modifier =      (-4, -12, -4)
     high_hill_noise_modifier =     (-3, -10, -3)
     hill_noise_modifier =          (-2, -6, -2)
 
+    # This is the base "mountain color". Elevations above this size will have their colors interpolated with this 
+    # color in order to give a more mountainous appearance
     mountain_color = (50, 57, 28)
 
     ## Second loop - this sets each pixel's color based on colors defined in _biome_satellite_colors

--- a/worldengine/draw.py
+++ b/worldengine/draw.py
@@ -53,6 +53,52 @@ _biome_colors = {
     'tropical very dry forest': (160, 255, 128),
 }
 
+
+_biome_satellite_colors = {
+    'ocean': (23, 94, 145),
+    'sea': (23, 94, 145),
+    'ice': (255, 255, 255),
+    'subpolar dry tundra': (186, 199, 206),
+    'subpolar moist tundra': (186, 195, 202),
+    'subpolar wet tundra': (186, 195, 204),
+    'subpolar rain tundra': (186, 200, 210),
+    'polar desert': (182, 195, 201),
+    'boreal desert': (132, 146, 143),
+    'cool temperate desert': (183, 163, 126),
+    'warm temperate desert': (166, 142, 104),
+    'subtropical desert': (205, 181, 137),
+    'tropical desert': (203, 187, 153),
+    'boreal rain forest': (21, 29, 8),
+    'cool temperate rain forest': (25, 34, 15),
+    'warm temperate rain forest': (19, 28, 7),
+    'subtropical rain forest': (48, 60, 24),
+    'tropical rain forest': (21, 38, 6),
+    'boreal wet forest': (6, 17, 11),
+    'cool temperate wet forest': (6, 17, 11),
+    'warm temperate wet forest': (44, 48, 19),
+    'subtropical wet forest': (23, 36, 10),
+    'tropical wet forest': (23, 36, 10),
+    'boreal moist forest': (31, 39, 18),
+    'cool temperate moist forest': (31, 39, 18),
+    'warm temperate moist forest': (36, 42, 19),
+    'subtropical moist forest': (23, 31, 10),
+    'tropical moist forest': (24, 36, 11),
+    'warm temperate dry forest': (52, 51, 30),
+    'subtropical dry forest': (53, 56, 30),
+    'tropical dry forest': (54, 60, 30),
+    'boreal dry scrub': (73, 70, 61),
+    'cool temperate desert scrub': (80, 58, 44),
+    'warm temperate desert scrub': (92, 81, 49),
+    'subtropical desert scrub': (68, 57, 35),
+    'tropical desert scrub': (107, 87, 60),
+    'cool temperate steppe': (95, 82, 50),
+    'warm temperate thorn scrub': (77, 81, 48),
+    'subtropical thorn woodland': (27, 40, 12),
+    'tropical thorn woodland': (40, 62, 15),
+    'tropical very dry forest': (87, 81, 49),
+}
+
+
 # ----------------
 # Helper functions
 # ----------------
@@ -146,6 +192,9 @@ class ImagePixelSetter(object):
             color = (color[0], color[1], color[2], 255)
         self.pixels[x, y] = color
 
+    def get_pixel(self, x, y):
+        return self.pixels[x, y]
+
     def complete(self):
         try:
             self.img.save(self.filename)
@@ -229,6 +278,189 @@ def draw_grayscale_heightmap(world, target):
     for y in range(world.height):
         for x in range(world.width):
             target.set_pixel(x, y, (c[y, x], c[y, x], c[y, x], 255))
+
+
+def draw_satellite(world, target):
+    # Not sure what this first part is doing - copied from draw_greyscale_heightmap 
+    # I believe it is normalizing the heightmap values between 1 and 255?
+    # This function will use those values later, so this loop is kept in
+    min_elev_sea = None
+    max_elev_sea = None
+    min_elev_land = None
+    max_elev_land = None
+    for y in xrange(world.height):
+        for x in xrange(world.width):
+            e = world.elevation['data'][y, x]
+            if world.is_land((x, y)):
+                if min_elev_land is None or e < min_elev_land:
+                    min_elev_land = e
+                if max_elev_land is None or e > max_elev_land:
+                    max_elev_land = e
+            else:
+                if min_elev_sea is None or e < min_elev_sea:
+                    min_elev_sea = e
+                if max_elev_sea is None or e > max_elev_sea:
+                    max_elev_sea = e
+
+    elev_delta_land = max_elev_land - min_elev_land
+    elev_delta_sea = max_elev_sea - min_elev_sea
+    ## -----------------------------------------------------------------------###
+
+    noise_range = 10 # a random value between -noise_range and noise_range will be added to the rgb of each pixel
+
+    high_mountain_elev = 215
+    mountain_elev      = 175
+    high_hill_elev     = 160
+    hill_elev          = 145
+
+    high_mountain_noise_modifier = (10, 6,   10)
+    mountain_noise_modifier =      (-4, -12, -4)
+    high_hill_noise_modifier =     (-3, -10, -3)
+    hill_noise_modifier =          (-2, -6, -2)
+
+    mountain_color = (50, 57, 28)
+
+    ## Second loop - this sets each pixel's color based on colors defined in _biome_satellite_colors
+    for y in xrange(world.height):
+        for x in xrange(world.width):
+            e = world.elevation['data'][y, x]
+            v = world.biome[y, x]
+            biome_r, biome_g, biome_b = _biome_satellite_colors[v]
+
+            if world.is_land((x, y)):
+                c = int(((e - min_elev_land) * 127) / elev_delta_land)+128
+                
+                ## Generate some random noise to apply to this pixel
+                #  There is noise for each element of the rgb value
+                #  This noise will be further modified by the height of this tile
+                noise = (random.randint(-noise_range, noise_range), 
+                         random.randint(-noise_range, noise_range), 
+                         random.randint(-noise_range, noise_range))
+
+                ####### Case 1 - elevation is very high ########
+                if c > high_mountain_elev:     
+                    # Take the random noise, and color it based on the mountain's modifier.
+                    # In this case, it makes the area slightly brighter to simulate snow-topped mountains.
+                    noise = noise[0] + high_mountain_noise_modifier[0], \
+                            noise[1] + high_mountain_noise_modifier[1], \
+                            noise[2] + high_mountain_noise_modifier[2]
+
+                    # Average the biome's color with the mountain_color to tint the terrain
+                    biome_r = int((biome_r + mountain_color[0])/2)
+                    biome_g = int((biome_g + mountain_color[1])/2)
+                    biome_b = int((biome_b + mountain_color[2])/2)
+                #################################################
+
+                ####### Case 1 - elevation is high ########
+                elif c > mountain_elev:   
+                    # Take the random noise, and color it based on the mountain's modifier.
+                    # In this case, it makes the area slightly darker, especially draining the green
+                    noise = noise[0] + mountain_noise_modifier[0], \
+                            noise[1] + mountain_noise_modifier[1], \
+                            noise[2] + mountain_noise_modifier[2]
+
+                    # Average the biome's color with the mountain_color to tint the terrain
+                    biome_r = int((biome_r + mountain_color[0])/2)
+                    biome_g = int((biome_g + mountain_color[1])/2)
+                    biome_b = int((biome_b + mountain_color[2])/2)
+                #################################################
+
+                ####### Case 3 - elevation is somewhat high ########
+                elif c > high_hill_elev:   
+                    # Make the random noise somewhat darker, and drain a little bit of green
+                    noise = noise[0] - high_hill_noise_modifier[0], \
+                            noise[1] - high_hill_noise_modifier[1], \
+                            noise[2] - high_hill_noise_modifier[2]
+
+                ####### Case 3 - elevation is a little bit high ########
+                elif c > hill_elev:   
+                    # Make the random noise just a little bit darker, and drain a little bit of green
+                    noise = noise[0] - 2, noise[1] - 6, noise[2] - 2
+
+            ### Ocean 
+            else:
+                c = int(((e - min_elev_sea) * 127) / elev_delta_sea)
+                noise = (0, 0, 0)
+
+            # This adds a base modifier to the biome color based on height
+            modifier = int(c / 10)
+
+            # Combine the biome color, the height modifier, and the noise value 
+            # to get the rgb value
+            r = biome_r + modifier + noise[0]
+            g = biome_g + modifier + noise[1]
+            b = biome_b + modifier + noise[2]
+
+            # Set pixel to this color. This initial color will be accessed and modified later when 
+            # the map is smoothed and shaded.
+            target.set_pixel(x, y, (r, g, b, 255))
+
+
+    # Loop through and average a pixel with its neighbors to smooth transitions between biomes
+    for y in xrange(1, world.height-1):
+        for x in xrange(1, world.width-1):
+            ## Only smooth land tiles
+            if world.is_land((x, y)):
+                # Lists to hold the separated rgb values of the neighboring pixels
+                all_r = []
+                all_g = []
+                all_b = []
+
+                # Loop through this pixel and all neighboring pixels
+                for j in xrange(y-1, y+2):
+                    for i in xrange(x-1, x+2):
+                        # Don't include ocean in the smoothing, if this tile happens to border an ocean
+                        if world.is_land((i, j)):
+                            # Grab each rgb value and append to the list
+                            r, g, b, a = target.get_pixel(i, j)
+                            all_r.append(r)
+                            all_g.append(g)
+                            all_b.append(b)
+
+                # Making sure there is at least one valid tile to be smoothed before we attempt to average the values
+                if all_r:
+                    avg_r = int(sum(all_r) / len(all_r))
+                    avg_g = int(sum(all_g) / len(all_g))
+                    avg_b = int(sum(all_b) / len(all_b))
+
+                    ## Setting color of the pixel again - this will be once more modified by the shading algorithm
+                    target.set_pixel(x, y, (avg_r, avg_g, avg_b, 255))
+
+    
+    # How many tiles to average together when comparing this tile's elevation to the previous tiles.
+    shade_size = 5
+    # How much to multiply the difference in elevation between this tile and the previous tile
+    # Higher will result in starker contrast between high and low areas.
+    difference_multiplier = 9
+
+    # "Shade" the map by sending beams of light west to east, and increasing or decreasing value of pixel based on elevation difference
+    for y in xrange(shade_size-1, world.height-shade_size-1):
+        for x in xrange(shade_size-1, world.width-shade_size-1):
+            if world.is_land((x, y)):
+                r, g, b, a = target.get_pixel(x, y)
+                
+                # Build up list of elevations in the previous n tiles, where n is the shadow size.
+                # This goes left to right, so it would be the previous tiles on the same y level  
+                prev_elevs = [ world.elevation['data'][y-n, x-n] for n in xrange(1, shade_size+1)]
+
+                # Take the average of the height of the previous n tiles
+                avg_prev_elev = int( sum(prev_elevs) / len(prev_elevs) )
+
+                # Find the difference between this tile's elevation, and the average of the previous elevations
+                difference = int(world.elevation['data'][y, x] - avg_prev_elev)
+
+                # Amplify the difference
+                difference = difference * difference_multiplier
+
+                # The amplified difference is now translated into the rgb of the tile.
+                # This adds light to tiles higher that the previous average, and shadow
+                # to tiles lower than the previous average
+                r += difference
+                g += difference
+                b += difference
+
+                # Set the final color for this pixel
+                target.set_pixel(x, y, (r, g, b, 255))
 
 
 def draw_elevation(world, shadow, target):
@@ -551,8 +783,13 @@ def draw_ancientmap_on_file(world, filename, resize_factor=1,
                     verbose)
     img.complete()
 
-
 def draw_scatter_plot_on_file(world, filename):
     img = ImagePixelSetter(512, 512, filename)
     draw_scatter_plot(world, 512, img)
+    img.complete()
+
+
+def draw_satellite_on_file(world, filename):
+    img = ImagePixelSetter(world.width, world.height, filename)
+    draw_satellite(world, img)
     img.complete()

--- a/worldengine/draw.py
+++ b/worldengine/draw.py
@@ -53,7 +53,12 @@ _biome_colors = {
     'tropical very dry forest': (160, 255, 128),
 }
 
-
+# These colors are used when drawing the satellite view map
+# The rgb values were hand-picked from an actual high-resolution 
+# satellite map of earth. However, many values are either too similar
+# to each other or otherwise need to be updated. It is recommended that
+# further research go into these values, making sure that each rgb is
+# actually picked from a region on earth that has the matching biome
 _biome_satellite_colors = {
     'ocean': (23, 94, 145),
     'sea': (23, 94, 145),

--- a/worldengine/generation.py
+++ b/worldengine/generation.py
@@ -200,7 +200,7 @@ def generate_world(w, step):
 
     # Prepare sufficient seeds for the different steps of the generation
     rng = numpy.random.RandomState(w.seed)  # create a fresh RNG in case the global RNG is compromised (i.e. has been queried an indefinite amount of times before generate_world() was called)
-    sub_seeds = rng.randint(0, 4294967295, size=100)  # sys.maxsize didn't quite work
+    sub_seeds = rng.randint(0, 2147483647, size=100)  # sys.maxsize didn't quite work
     seed_dict = {
                  'PrecipitationSimulation': sub_seeds[ 0],  # after 0.19.0 do not ever switch out the seeds here to maximize seed-compatibility
                  'ErosionSimulation':       sub_seeds[ 1],


### PR DESCRIPTION
This branch adds functionality for creating a "Satellite map" of the generated world. This is currently an option, default false, toggled on with the --sat command when running.

Additional work may need to be done in selecting more appropriate biome colors and tuning the algorithm to display elevation / shading, to get a more realistic result.

Some sample outputs are attached here:

![seed_35066_satellite](https://cloud.githubusercontent.com/assets/8039081/10901029/8e13c412-819c-11e5-938f-a05a3379e9de.png)
![seed_53057_satellite](https://cloud.githubusercontent.com/assets/8039081/10901030/8e177a62-819c-11e5-8452-9a03a9fa8734.png)