### PR TITLE
Removed (almost) every last trace of support for pickle

### DIFF
--- a/tests/biome_test.py
+++ b/tests/biome_test.py
@@ -121,8 +121,8 @@ class TestBiome(unittest.TestCase):
         self.assertEqual('warm temperate wet forest', biome_index_to_name(40))
 
     def test_locate_biomes(self):
-        w = World.open_protobuf("%s/biome_test.world" % self.tests_data_dir)
-        cm, biome_cm = BiomeSimulation().execute(w, 6908)
+        w = World.open_protobuf("%s/seed_28070.world" % self.tests_data_dir)
+        cm, biome_cm = BiomeSimulation().execute(w, 28070)
 
     @staticmethod
     def name():

--- a/tests/blessed_images/generated_blessed_images.py
+++ b/tests/blessed_images/generated_blessed_images.py
@@ -8,7 +8,6 @@ A script, generate_blessed_images, can be used to regenerate blessed images
 """
 
 import os
-import platform
 from worldengine.world import *
 from worldengine.draw import *
 from worldengine.image_io import PNGWriter
@@ -27,10 +26,7 @@ def main(blessed_images_dir, tests_data_dir):
     draw_world_on_file(w, "%s/world_28070.png" % blessed_images_dir)
     draw_temperature_levels_on_file(w, "%s/temperature_28070.png" % blessed_images_dir)
     draw_biome_on_file(w, "%s/biome_28070.png" % blessed_images_dir)
-
-    w_large = World.from_pickle_file("%s/py%s_seed_48956.world" % (tests_data_dir, platform.python_version_tuple()[0]))
     draw_ancientmap_on_file(w, "%s/ancientmap_28070_factor3.png" % blessed_images_dir, resize_factor=3)
-    draw_ancientmap_on_file(w_large, "%s/ancientmap_48956.png" % blessed_images_dir, resize_factor=1)
 
     img = PNGWriter.rgba_from_dimensions(w.width * 2, w.height * 2, "%s/rivers_28070_factor2.png" % blessed_images_dir)
     draw_rivers_on_image(w, img, factor=2)

--- a/tests/data/data_generator.py
+++ b/tests/data/data_generator.py
@@ -8,13 +8,18 @@ because the plate simulation steps do not provide the same results on all the pl
 """
 
 import os
-import platform
-from worldengine.plates import _plates_simulation
+from worldengine.plates import world_gen, _plates_simulation
 
 
 def main(tests_data_dir):
-    w = _plates_simulation("Foo", 300, 200, 279)
-    w.to_pickle_file("%s/py%s_plates_279.world" % (tests_data_dir, platform.python_version_tuple()[0]))
+    w = world_gen("seed_28070", 300, 200, 28070)
+    w.protobuf_to_file("%s/seed_28070.world" % tests_data_dir)
+
+    # w = world_gen("seed_48956", 450, 300, 48956)
+    # w.protobuf_to_file("%s/seed_48956.world" % tests_data_dir)
+
+    # w = world_gen("biome_test", 128, 128, 6908)
+    # w.protobuf_to_file("%s/biome_test.world" % tests_data_dir)
 
 
 if __name__ == '__main__':

--- a/tests/data/data_generator.py
+++ b/tests/data/data_generator.py
@@ -15,12 +15,6 @@ def main(tests_data_dir):
     w = world_gen("seed_28070", 300, 200, 28070)
     w.protobuf_to_file("%s/seed_28070.world" % tests_data_dir)
 
-    # w = world_gen("seed_48956", 450, 300, 48956)
-    # w.protobuf_to_file("%s/seed_48956.world" % tests_data_dir)
-
-    # w = world_gen("biome_test", 128, 128, 6908)
-    # w.protobuf_to_file("%s/biome_test.world" % tests_data_dir)
-
 
 if __name__ == '__main__':
     blessed_images_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/drawing_functions_test.py
+++ b/tests/drawing_functions_test.py
@@ -1,5 +1,4 @@
 import unittest
-import platform
 
 from worldengine.drawing_functions import draw_ancientmap, gradient, draw_rivers_on_image
 from worldengine.world import World
@@ -13,13 +12,7 @@ class TestDrawingFunctions(TestBase):
         super(TestDrawingFunctions, self).setUp()
         self.w = World.open_protobuf("%s/seed_28070.world" % self.tests_data_dir)
 
-    def test_draw_ancient_map_factor1(self):
-        w_large = World.from_pickle_file("%s/py%s_seed_48956.world" % (self.tests_data_dir, platform.python_version_tuple()[0]))
-        target = PNGWriter.rgba_from_dimensions(w_large.width, w_large.height)
-        draw_ancientmap(w_large, target, resize_factor=1)
-        self._assert_img_equal("ancientmap_48956", target)
-
-    def test_draw_ancient_map_factor3(self):
+    def test_draw_ancient_map(self):
         target = PNGWriter.rgba_from_dimensions(self.w.width * 3, self.w.height * 3)
         draw_ancientmap(self.w, target, resize_factor=3)
         self._assert_img_equal("ancientmap_28070_factor3", target)

--- a/tests/generation_test.py
+++ b/tests/generation_test.py
@@ -1,5 +1,4 @@
 import unittest
-import platform
 from worldengine.plates import Step, center_land, world_gen
 from worldengine.world import World
 
@@ -30,7 +29,7 @@ class TestGeneration(TestBase):
         return borders_total_elevation / n_cells_on_border
 
     def test_center_land(self):
-        w = World.from_pickle_file("%s/py%s_plates_279.world" % (self.tests_data_dir, platform.python_version_tuple()[0]))
+        w = World.open_protobuf("%s/seed_28070.world" % self.tests_data_dir)
 
         # We want to have less land than before at the borders
         el_before = TestGeneration._mean_elevation_at_borders(w)

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -2,39 +2,11 @@ import unittest
 from worldengine.plates import Step, world_gen
 from worldengine.world import World
 from worldengine.common import _equal
-import tempfile
-import os
 
 class TestSerialization(unittest.TestCase):
 
     def setUp(self):
         self.maxDiff = None
-
-    def test_pickle_serialize_unserialize(self):
-        w = world_gen("Dummy", 32, 16, 1, step=Step.get_by_name("full"))
-        f = tempfile.NamedTemporaryFile(delete=False).name
-        w.to_pickle_file(f)
-        unserialized = World.from_pickle_file(f)
-        os.remove(f)
-        self.assertTrue(_equal(w.elevation['data'], unserialized.elevation['data']))
-        self.assertEqual(w.elevation['thresholds'], unserialized.elevation['thresholds'])
-        self.assertTrue(_equal(w.ocean,             unserialized.ocean))
-        self.assertTrue(_equal(w.biome,             unserialized.biome))
-        self.assertTrue(_equal(w.humidity,          unserialized.humidity))
-        self.assertTrue(_equal(w.irrigation,        unserialized.irrigation))
-        self.assertTrue(_equal(w.permeability,      unserialized.permeability))
-        self.assertTrue(_equal(w.watermap,          unserialized.watermap))
-        self.assertTrue(_equal(w.precipitation,     unserialized.precipitation))
-        self.assertTrue(_equal(w.temperature,       unserialized.temperature))
-        self.assertTrue(_equal(w.sea_depth,         unserialized.sea_depth))
-        self.assertEquals(w.seed,                   unserialized.seed)
-        self.assertEquals(w.n_plates,               unserialized.n_plates)
-        self.assertTrue(_equal(w.ocean_level,       unserialized.ocean_level))
-        self.assertTrue(_equal(w.lake_map,          unserialized.lake_map))
-        self.assertTrue(_equal(w.river_map,         unserialized.river_map))
-        self.assertEquals(w.step,                   unserialized.step)
-        self.assertEqual(sorted(dir(w)),            sorted(dir(unserialized)))
-        self.assertEqual(w, unserialized)
 
     def test_protobuf_serialize_unserialize(self):
         w = world_gen("Dummy", 32, 16, 1, step=Step.get_by_name("full"))

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -2,7 +2,6 @@ import sys
 from argparse import ArgumentParser
 import os
 import numpy
-import pickle
 import worldengine.generation as geo
 from worldengine.common import array_to_matrix, set_verbose, print_verbose
 from worldengine.draw import draw_ancientmap_on_file, draw_biome_on_file, draw_ocean_on_file, \
@@ -36,9 +35,7 @@ def generate_world(world_name, width, height, seed, num_plates, output_dir,
     # Save data
     filename = "%s/%s.world" % (output_dir, world_name)
     with open(filename, "wb") as f:
-        if world_format == 'pickle':
-            pickle.dump(w, f, pickle.HIGHEST_PROTOCOL)
-        elif world_format == 'protobuf':
+        if world_format == 'protobuf':
             f.write(w.protobuf_serialize())
         else:
             print("Unknown format '%s', not saving " % world_format)
@@ -186,32 +183,18 @@ def __seems_protobuf_worldfile__(world_filename):
     return worldengine_tag == World.worldengine_tag()
 
 
-def __seems_pickle_file__(world_filename):
-    last_byte = __get_last_byte__(world_filename)
-    return str(last_byte) == '.'
-
-
 def load_world(world_filename):
     pb = __seems_protobuf_worldfile__(world_filename)
-    pi = __seems_pickle_file__(world_filename)
-    if pb and pi:
-        print("we cannot distinguish if the file is a pickle or a protobuf "
-              "world file. Trying to load first as protobuf then as pickle "
-              "file")
+    if pb:
+        # print("we cannot distinguish if the file is a pickle or a protobuf "
+        #       "world file. Trying to load first as protobuf then as pickle "
+        #       "file")
         try:
             return World.open_protobuf(world_filename)
         except Exception:
-            try:
-                return World.from_pickle_file(world_filename)
-            except Exception:
-                raise Exception("Unable to load the worldfile neither as protobuf or pickle file")
-
-    elif pb:
-        return World.open_protobuf(world_filename)
-    elif pi:
-        return World.from_pickle_file(world_filename)
+            raise Exception("Unable to load the worldfile as protobuf file")
     else:
-        raise Exception("The given worldfile does not seem a pickle or a protobuf file")
+        raise Exception("The given worldfile does not seem to be a protobuf file")
 
 
 def print_world_info(world):

--- a/worldengine/cli/main.py
+++ b/worldengine/cli/main.py
@@ -186,9 +186,6 @@ def __seems_protobuf_worldfile__(world_filename):
 def load_world(world_filename):
     pb = __seems_protobuf_worldfile__(world_filename)
     if pb:
-        # print("we cannot distinguish if the file is a pickle or a protobuf "
-        #       "world file. Trying to load first as protobuf then as pickle "
-        #       "file")
         try:
             return World.open_protobuf(world_filename)
         except Exception:

--- a/worldengine/simulations/erosion.py
+++ b/worldengine/simulations/erosion.py
@@ -28,18 +28,6 @@ def in_circle(radius, center_x, center_y, x, y):
     return square_dist <= radius ** 2
 
 
-def _numpy_to_matrix(numpy_array):
-    """Convert a bi-dimensional numpy array to a plain Python matrix.
-
-    This is used because currently we do not know how to serialize numpy
-    arrays :( with pickle. In the future we will use pytables/hdf5"""
-    # TODO: Is this still true? Pickle didn't seem to cause problems for me. /tcld
-
-    width = numpy_array.shape[0]
-    height = numpy_array.shape[1]
-    return [[numpy_array[x, y] for x in range(width)] for y in range(height)]
-
-
 class ErosionSimulation(object):
     def __init__(self):
         self.wrap = True

--- a/worldengine/world.py
+++ b/worldengine/world.py
@@ -1,4 +1,3 @@
-import pickle
 import numpy
 
 from worldengine.biome import Biome, BorealDesert, BorealDryScrub, BorealMoistForest, \
@@ -48,15 +47,6 @@ class World(object):
     #
     # Serialization/Unserialization
     #
-
-    @classmethod
-    def from_pickle_file(cls, filename):
-        with open(filename, "rb") as f:
-            return pickle.load(f)
-
-    def to_pickle_file(self, filename):
-        with open(filename, "wb") as f:
-            pickle.dump(self, f, pickle.HIGHEST_PROTOCOL)
 
     @classmethod
     def from_dict(cls, dict):


### PR DESCRIPTION
Since I wanted to [add a new variable to the World](https://github.com/Mindwerks/worldengine/pull/189) I noticed that I couldn't regenerate the pickle test-worlds after https://github.com/Mindwerks/worldengine/pull/187 had been merged (I did it via a bash-script before, but WorldEngine didn't take a parameter to output a pickle-world anymore).
After a bit of thinking I noticed that "load-only support" for pickle is worthless once new variables are added to the world since compatibility will most likely be lost anyway; @psi29a [seemed to agree](https://github.com/Mindwerks/worldengine/pull/187) that pickle-support could probably be purged completely.

So what this does might seem a lot:
* completely remove pickle-support
* update ```data_generator.py``` so it actually outputs all necessary data (should have done that earlier)
* also updated the worlds data to use a single world-file with seed 28070 instead of four different files (I didn't see the purpose; comments on that are welcome)
* removed two tests that seemed useless now

**EDIT:** [Data for this PR](https://github.com/Mindwerks/worldengine-data/pull/13)