### PR TITLE
Update __init__.py - resolve Windows error 32

### DIFF
--- a/worldengine/imex/__init__.py
+++ b/worldengine/imex/__init__.py
@@ -117,7 +117,7 @@ def export(world, export_filetype = 'GTiff', export_datatype = 'float32', path =
 
     # take elevation data and push it into an intermediate GTiff format (some formats don't support being written by Create())
     inter_driver = gdal.GetDriverByName("GTiff")
-    _, inter_file = tempfile.mkstemp()  # returns: (file-handle, absolute path)
+    fh_inter_file, inter_file = tempfile.mkstemp()  # returns: (file-handle, absolute path)
     initial_ds = inter_driver.Create(inter_file, world.width, world.height, 1, gdal_type)
     band = initial_ds.GetRasterBand(1)
     
@@ -129,4 +129,6 @@ def export(world, export_filetype = 'GTiff', export_datatype = 'float32', path =
     initial_ds = gdal.Open(inter_file)
     final_driver.CreateCopy('%s-%d.%s' % (path, bpp, export_filetype), initial_ds)
 
+    initial_ds = None
+    os.close(fh_inter_file)
     os.remove(inter_file)


### PR DESCRIPTION
When running export in Windows, errors out: "WindowsError: [Error 32] The process cannot access the file because it is in use by another process: path_to_temp_file"

Flushing (new line 132) and adding a call to close with the file handle (new line 134) resolves the error. Just flushing, or just closing, does not.

Thanks!