### PR TITLE
Fix AttributeError: 'World' object has no attribute

### DIFF
--- a/worldengine/draw.py
+++ b/worldengine/draw.py
@@ -821,5 +821,5 @@ def draw_satellite_on_file(world, filename):
 
 
 def draw_icecaps_on_file(world, filename):
-    img = PNGWriter.grayscale_from_array(world.icecap, filename, scale_to_range=True)
+    img = PNGWriter.grayscale_from_array(world.layers['icecap'].data, filename, scale_to_range=True)
     img.complete()

--- a/worldengine/imex/__init__.py
+++ b/worldengine/imex/__init__.py
@@ -92,7 +92,7 @@ def export(world, export_filetype = 'GTiff', export_datatype = 'float32', path =
         raise TypeError("Type of data not recognized or not supported by GDAL: %s" % export_datatype)
 
     # massage data to scale between the absolute min and max
-    elevation = numpy.copy(world.elevation['data'])
+    elevation = numpy.copy(world.layers['elevation'].data)
 
     # shift data according to minimum possible value
     if signed:


### PR DESCRIPTION
This pull request fixes #235 and makes the following type of command line interactions work again:

```
python worldengine --ice -n foo
python worldengine export foo.world
```