### PR TITLE
transpose next_land_dynamic for greater speed and clarity

### DIFF
--- a/worldengine/generation.py
+++ b/worldengine/generation.py
@@ -158,18 +158,16 @@ def sea_depth(world, sea_level):
         height, width = ocean.shape
 
         for dist in range(max_radius):
-            for y in range(height):
-                for x in range(width):
-                    if next_land[y,x] == -1:
+            indices = numpy.transpose(numpy.where(next_land==dist))
+            for y, x in indices:
+                for dy in range(-1, 2):
+                    ny = y + dy
+                    if 0 <= ny < height:
                         for dx in range(-1, 2):
                             nx = x + dx
                             if 0 <= nx < width:
-                                for dy in range(-1, 2):
-                                    ny = y + dy
-                                    if 0 <= ny < height and (dx != 0 or dy != 0):
-                                        if next_land[ny,nx] == dist:
-                                            next_land[y,x] = dist+1
-
+                                if next_land[ny,nx] == -1:
+                                    next_land[ny,nx] = dist + 1
         return next_land
 
     # We want to multiply the raw sea_depth by one of these factors 


### PR DESCRIPTION
Here's another one I prepared yesterday.

This uses the fact that only very few coodinates are actually `dist` away from land. It then iterates over these coordinates and looks if the distance of their neighbours happens to be unknown. Only then an update is made. This is actually the more logical thing to do because it checks for `dist` directly at the beginning of the loop iterating over `dist` and it checks `next_land[ny,nx]` in the inner loop and makes a change to the same coordinate. 

The original implementation had this backwards. It checked for unknown distances in the outer loop and for the known distance in the inner loop which makes for a lot more checks because of how the numbers work out.

I think that change in ordering is where the main speedup comes from. Doing the more logical thing also saves two comparisons in the inner loop and is likely to be a tiny bit more cache friendly, but I don't think these things matter too much. Using numpy here makes the code look a bit cleaner but mainly it hides away some of the loops, so I don't think it is a great speedup in and of itself. I didn't measure that in detail though. The code is now reasonably fast and it looks cleaner so that was where I stopped investigating.

Cheers

Alex