### PR TITLE
Final speedup PR

### DIFF
--- a/worldengine/model/world.py
+++ b/worldengine/model/world.py
@@ -149,24 +149,21 @@ class World(object):
 
     @staticmethod
     def _to_protobuf_matrix(matrix, p_matrix, transformation=None):
-        for row in matrix:
+
+        m = matrix
+        if transformation is not None:
+            t = numpy.vectorize(transformation)
+            m = t(m)
+
+        for row in m:
             p_row = p_matrix.rows.add()
-            for cell in row:
-                '''
-                When using numpy, certain primitive types are replaced with
-                numpy-specifc versions that, even though mostly compatible,
-                cannot be digested by protobuf. This might change at some point;
-                for now a conversion is necessary.
-                '''
-                if type(cell) is numpy.bool_:
-                    value = bool(cell)
-                elif type(cell) is numpy.uint16:
-                    value = int(cell)
-                else:
-                    value = cell
-                if transformation:
-                    value = transformation(value)
-                p_row.cells.append(value)
+            '''
+            When using numpy, certain primitive types are replaced with
+            numpy-specifc versions that, even though mostly compatible,
+            cannot be digested by protobuf. This might change at some point;
+            for now a conversion is necessary.
+            '''
+            p_row.cells.extend(row.tolist())
 
     @staticmethod
     def _to_protobuf_quantiles(quantiles, p_quantiles):

--- a/worldengine/simulations/erosion.py
+++ b/worldengine/simulations/erosion.py
@@ -138,8 +138,8 @@ class ErosionSimulation(object):
         #     we mark them as rivers. While looking, the cells with no
         #     out-going flow, above water flow threshold and are still
         #     above sea level are marked as 'sources'.
-        for x in range(0, world.width - 1):
-            for y in range(0, world.height - 1):
+        for y in range(0, world.height - 1):
+            for x in range(0, world.width - 1):
                 rain_fall = world.layers['precipitation'].data[y, x]
                 water_flow[y, x] = rain_fall
 


### PR DESCRIPTION
This is the last thing I had prepared. 

I discovered that `numpy.tolist` does the main thing of what `_to_protobuf_matrix` is trying to do sans transformation. We can also use numpy to vectorise the transformation which looks a bit cleaner. 

I also picked the extremely low hanging fruit of making the iteration order in `river_sources` cache friendly.

Again this is not that much faster ~10s for the 1024*512 map.

Here is how the final timing of 2m12s is mostly spent:

- ~16% `platec.step` (as discussed in #246)
- ~6% `irrigation.calculate` (somebody already took numpy to that problem, so there is little to be gained, I assume)
- ~6% `protobuf.internal.encoder.EncodeRepeatedField` (mostly type checks, AFAICT)
- ~5% `PNGWriter.set_pixel` (maybe a faster numpy->image format will fall out of my work on ancient map)
- ~4% `erosion.river_sources` (this was at about 6% before the change of iteration order)

And that's that.