### PR TITLE
Refactor ancient map

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ We would like to thank you great people who helped us while working on WorldEngi
 
 * [Stephan](https://github.com/tcld) made WorldEngine make heavy use of numpy, helping to speed up the generation. He also made world-generation much more reproducible and helped improve compatibility with Python 3.
 
+* [Alex](https://github.com/MM1nd) made things generally run faster and look cleaner by better employing numpy.
+
 History
 =======
 

--- a/tests/drawing_functions_test.py
+++ b/tests/drawing_functions_test.py
@@ -17,6 +17,13 @@ class TestDrawingFunctions(TestBase):
         draw_ancientmap(self.w, target, resize_factor=3)
         self._assert_img_equal("ancientmap_28070_factor3", target)
 
+    def test_draw_ancient_map_outer_borders(self):
+        # TODO: So far this only calls the function without testing the result.
+        # Add a blessed image with borders, maybe
+        target = PNGWriter.rgba_from_dimensions(self.w.width * 3, self.w.height * 3)
+        draw_ancientmap(self.w, target, resize_factor=3, draw_outer_land_border=True)
+
+
     def test_gradient(self):
         self._assert_are_colors_equal((10, 20, 40),
                                       gradient(0.0, 0.0, 1.0, (10, 20, 40), (0, 128, 240)))

--- a/worldengine/drawing_functions.py
+++ b/worldengine/drawing_functions.py
@@ -370,12 +370,10 @@ def draw_ancientmap(world, target, resize_factor=1,
     land_color = (
         181, 166, 127, 255)  # TODO: Put this in the argument list too??
 
-
-
-    scaled_ocean = world.ocean.repeat(resize_factor,0).repeat(resize_factor,1)
+    scaled_ocean = world.ocean.repeat(resize_factor, 0).repeat(resize_factor, 1)
     
     borders = numpy.zeros((resize_factor * world.height, resize_factor * world.width), bool)
-    borders[count_neighbours(scaled_ocean)>0] = True
+    borders[count_neighbours(scaled_ocean) > 0] = True
     borders[scaled_ocean] = False
 
     # cache neighbours count at different radii
@@ -390,7 +388,7 @@ def draw_ancientmap(world, target, resize_factor=1,
 
         for i in range(2):
             _outer_borders =  numpy.zeros((resize_factor * world.height, resize_factor * world.width), bool)
-            _outer_borders[count_neighbours(inner_borders)>0] = True
+            _outer_borders[count_neighbours(inner_borders) > 0] = True
             _outer_borders[inner_borders] = False
             _outer_borders[numpy.logical_not(scaled_ocean)] = False
             outer_borders = _outer_borders

--- a/worldengine/drawing_functions.py
+++ b/worldengine/drawing_functions.py
@@ -56,48 +56,6 @@ def draw_rivers_on_image(world, target, factor=1):
 # Drawing ancient map
 # -------------------
 
-def _find_land_borders(world, factor):
-    _ocean = numpy.zeros((factor * world.height, factor * world.width), dtype=bool)
-    _borders = numpy.zeros((factor * world.height, factor * world.width), dtype=bool)
-
-    # scale ocean
-    for y in range(world.height * factor):  # TODO: numpy
-        for x in range(world.width * factor):
-            if world.is_ocean((int(x / factor), int(y / factor))):
-                _ocean[y, x] = True
-
-    def my_is_ocean(pos):
-        x, y = pos
-        return _ocean[y, x]
-
-    for y in range(world.height * factor):
-        for x in range(world.width * factor):
-            if not _ocean[y, x] and world.tiles_around_factor(factor, (x, y), radius=1, predicate=my_is_ocean):
-                _borders[y, x] = True
-    return _borders
-
-
-def _find_outer_borders(world, factor, inner_borders):
-    _ocean = numpy.zeros((factor * world.height, factor * world.width), dtype=bool)
-    _borders = numpy.zeros((factor * world.height, factor * world.width), dtype=bool)
-
-    # scale ocean
-    for y in range(world.height * factor):  # TODO: numpy
-        for x in range(world.width * factor):
-            if world.is_ocean((int(x / factor), int(y / factor))):
-                _ocean[y, x] = True
-
-    def is_inner_border(pos):
-        x, y = pos
-        return inner_borders[y, x]
-
-    for y in range(world.height * factor):
-        for x in range(world.width * factor):
-            if _ocean[y, x] and not inner_borders[y, x] and world.tiles_around_factor(factor, (x, y), radius=1, predicate=is_inner_border):
-                _borders[y, x] = True
-    return _borders
-
-
 def _find_mountains_mask(world, factor):
     _mask = numpy.zeros((world.height, world.width), float)
     _mask[world.elevation>world.get_mountain_level()] = 1.0
@@ -251,7 +209,7 @@ def _draw_glacier(pixels, x, y):
     pixels[y, x] = (rg, rg, 255, 255)
 
 
-def _draw_cold_parklands(pixels, x, y):
+def _draw_cold_parklands(pixels, x, y, w, h):
     b = (x ** int(y / 5) + x * 23 + y * 37 + (x * y) * 13) % 75
     r = 105 - b
     g = 96 - b
@@ -307,19 +265,19 @@ def _draw_hot_desert(pixels, x, y, w, h):
     _draw_desert_pattern(pixels, x, y, c)  
 
 
-def _draw_tundra(pixels, x, y):
+def _draw_tundra(pixels, x, y, w, h):
     _draw_shaded_pixel(pixels,x, y, 166, 148, 75)
 
 
-def _draw_steppe(pixels, x, y):
+def _draw_steppe(pixels, x, y, w, h):
     _draw_shaded_pixel(pixels, x, y, 96, 192, 96)
 
 
-def _draw_chaparral(pixels, x, y):
+def _draw_chaparral(pixels, x, y, w, h):
     _draw_shaded_pixel(pixels, x, y, 180, 171, 113)
 
 
-def _draw_savanna(pixels, x, y):
+def _draw_savanna(pixels, x, y, w, h):
     _draw_shaded_pixel(pixels, x, y, 255, 246, 188)
 
 
@@ -411,13 +369,34 @@ def draw_ancientmap(world, target, resize_factor=1,
 
     land_color = (
         181, 166, 127, 255)  # TODO: Put this in the argument list too??
-    borders = _find_land_borders(world, resize_factor)
+
+
+
+    scaled_ocean = world.ocean.repeat(resize_factor,0).repeat(resize_factor,1)
+    
+    borders = numpy.zeros((resize_factor * world.height, resize_factor * world.width), bool)
+    borders[count_neighbours(scaled_ocean)>0] = True
+    borders[scaled_ocean] = False
+
+    # cache neighbours count at different radii
+    border_neighbours = {}
+
+    border_neighbours[6] = numpy.rint(count_neighbours(borders, 6))
+    border_neighbours[9] = numpy.rint(count_neighbours(borders, 9))
 
     if draw_outer_land_border:
-        outer_borders = _find_outer_borders(world, resize_factor, borders)
-        outer_borders = _find_outer_borders(world, resize_factor, outer_borders)
+        inner_borders = borders
+        outer_borders = None
 
-    if draw_mountains:  # TODO: numpy offers masked arrays - maybe they can be leveraged for all this?
+        for i in range(2):
+            _outer_borders =  numpy.zeros((resize_factor * world.height, resize_factor * world.width), bool)
+            _outer_borders[count_neighbours(inner_borders)>0] = True
+            _outer_borders[inner_borders] = False
+            _outer_borders[numpy.logical_not(scaled_ocean)] = False
+            outer_borders = _outer_borders
+            inner_borders = outer_borders
+
+    if draw_mountains:
         mountains_mask = _find_mountains_mask(world, resize_factor)
 
     if draw_biome:
@@ -430,34 +409,6 @@ def draw_ancientmap(world, target, resize_factor=1,
     def unset_mask(pos):
         x, y = pos
         mountains_mask[y, x] = 0
-
-    def unset_boreal_forest_mask(pos):
-        x, y = pos
-        biome_masks['boreal forest'][y, x] = 0
-
-    def unset_temperate_forest_mask(pos):
-        x, y = pos
-        biome_masks['cool temperate forest'][y, x] = 0
-
-    def unset_warm_temperate_forest_mask(pos):
-        x, y = pos
-        biome_masks['warm temperate forest'][y, x] = 0
-
-    def unset_tropical_dry_forest_mask(pos):
-        x, y = pos
-        biome_masks['tropical dry forest group'][y, x] = 0
-
-    def unset_jungle_mask(pos):
-        x, y = pos
-        biome_masks['jungle'][y, x] = 0
-
-    def unset_hot_desert_mask(pos):
-        x, y = pos
-        biome_masks['hot desert'][y, x] = 0
-
-    def unset_cool_desert_mask(pos):
-        x, y = pos
-        biome_masks['cool desert'][y, x] = 0
 
     def on_border(pos):
         x, y = pos
@@ -520,8 +471,25 @@ def draw_ancientmap(world, target, resize_factor=1,
             "...drawing_functions.draw_oldmap_on_pixel: anti alias " +
             "Elapsed time " + str(elapsed_time) + " seconds.")
 
-    # Draw glacier
+
+    def _draw_biome(name, _func, w, h, r):
+        if verbose:
+            start_time = time.time()
+
+        for y in range(resize_factor * world.height):
+            for x in range(resize_factor * world.width):
+                if biome_masks[name][y, x] > 0:
+                    if r == 0 or border_neighbours[r][y,x] <= 2:
+                        _func(target, x, y, w, h)
+                        biome_masks[name][y-r:y+r+1,x-r:x+r+1] = 0.0
+
+        if verbose:
+            elapsed_time = time.time() - start_time
+            print(
+                "...drawing_functions.draw_ancientmap: " + name +
+                " Elapsed time " + str(elapsed_time) + " seconds.")
     if draw_biome:
+        # Draw glacier
         if verbose:
             start_time = time.time()
         for y in range(resize_factor * world.height):
@@ -534,89 +502,15 @@ def draw_ancientmap(world, target, resize_factor=1,
             print(
                 "...drawing_functions.draw_oldmap_on_pixel: draw glacier " +
                 "Elapsed time " + str(elapsed_time) + " seconds.")
-
-        # Draw tundra
-        if verbose:
-            start_time = time.time()
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['tundra'][y, x] > 0:
-                    _draw_tundra(target, x, y)
-        if verbose:
-            elapsed_time = time.time() - start_time
-            print(
-                "...drawing_functions.draw_oldmap_on_pixel: draw tundra " +
-                "Elapsed time " + str(elapsed_time) + " seconds.")
-
-        # Draw cold parklands
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['cold parklands'][y, x] > 0:
-                    _draw_cold_parklands(target, x, y)
-
-        # Draw steppes
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['steppe'][y, x] > 0:
-                    _draw_steppe(target, x, y)
-
-        # Draw chaparral
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['chaparral'][y, x] > 0:
-                    _draw_chaparral(target, x, y)
-
-        # Draw savanna
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['savanna'][y, x] > 0:
-                    _draw_savanna(target, x, y)
-
-        # Draw cool desert
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['cool desert'][y, x] > 0:
-                    w = 8
-                    h = 2
-                    r = 9
-                    if len(world.tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     predicate=on_border)) <= 2:
-                        _draw_cool_desert(target, x, y, w=w, h=h)
-                        world.on_tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     action=unset_cool_desert_mask)
-
-        # Draw hot desert
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['hot desert'][y, x] > 0:
-                    w = 8
-                    h = 2
-                    r = 9
-                    if len(world.tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     predicate=on_border)) <= 2:
-                        _draw_hot_desert(target, x, y, w=w, h=h)
-                        world.on_tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     action=unset_hot_desert_mask)
-
-        # Draw boreal forest
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['boreal forest'][y, x] > 0:
-                    w = 4
-                    h = 5
-                    r = 6
-                    if len(world.tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     predicate=on_border)) <= 2:
-                        _draw_boreal_forest(target, x, y, w=w, h=h)
-                        world.on_tiles_around_factor(
-                            resize_factor, (x, y),
-                            radius=r,
-                            action=unset_boreal_forest_mask)
+       
+        _draw_biome('tundra', _draw_tundra, 0, 0, 0) 
+        _draw_biome('cold parklands', _draw_cold_parklands, 0, 0, 0) 
+        _draw_biome('steppe', _draw_steppe, 0, 0, 0) 
+        _draw_biome('chaparral', _draw_chaparral, 0, 0, 0) 
+        _draw_biome('savanna', _draw_savanna, 0, 0, 0)  
+        _draw_biome('cool desert', _draw_cool_desert, 8, 2, 9)
+        _draw_biome('hot desert', _draw_hot_desert, 8, 2, 9)
+        _draw_biome('boreal forest', _draw_boreal_forest, 4, 5, 6)
 
         # Draw temperate forest
         for y in range(resize_factor * world.height):
@@ -625,64 +519,16 @@ def draw_ancientmap(world, target, resize_factor=1,
                     w = 4
                     h = 5
                     r = 6
-                    if len(world.tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     predicate=on_border)) <= 2:
+                    if border_neighbours[r][y,x] <= 2:
                         if rng.random_sample() <= .5:
                             _draw_temperate_forest1(target, x, y, w=w, h=h)
                         else:
                             _draw_temperate_forest2(target, x, y, w=w, h=h)
-                        world.on_tiles_around_factor(
-                            resize_factor, (x, y),
-                            radius=r,
-                            action=unset_temperate_forest_mask)
-
-        # Draw warm temperate forest
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['warm temperate forest'][y, x] > 0:
-                    w = 4
-                    h = 5
-                    r = 6
-                    if len(world.tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     predicate=on_border)) <= 2:
-                        _draw_warm_temperate_forest(target, x, y, w=w, h=h)
-                        world.on_tiles_around_factor(
-                            resize_factor, (x, y),
-                            radius=r,
-                            action=unset_warm_temperate_forest_mask)
-
-        # Draw dry tropical forest
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['tropical dry forest group'][y, x] > 0:
-                    w = 4
-                    h = 5
-                    r = 6
-                    if len(world.tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     predicate=on_border)) <= 2:
-                        _draw_tropical_dry_forest(target, x, y, w=w, h=h)
-                        world.on_tiles_around_factor(
-                            resize_factor, (x, y),
-                            radius=r,
-                            action=unset_tropical_dry_forest_mask)
-
-        # Draw jungle
-        for y in range(resize_factor * world.height):
-            for x in range(resize_factor * world.width):
-                if biome_masks['jungle'][y, x] > 0:
-                    w = 4
-                    h = 5
-                    r = 6
-                    if len(world.tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     predicate=on_border)) <= 2:
-                        _draw_jungle(target, x, y, w=w, h=h)
-                        world.on_tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     action=unset_jungle_mask)
+                        biome_masks['cool temperate forest'][y-r:y+r+1,x-r:x+r+1] = 0.0
+            
+        _draw_biome('warm temperate forest', _draw_warm_temperate_forest, 4, 5, 6)  
+        _draw_biome('tropical dry forest group', _draw_tropical_dry_forest, 4, 5, 6)
+        _draw_biome('jungle', _draw_jungle, 4, 5, 6)
 
     if draw_rivers:
         draw_rivers_on_image(world, target, resize_factor)
@@ -698,12 +544,13 @@ def draw_ancientmap(world, target, resize_factor=1,
                     h = 3 + int(world.level_of_mountain(
                         (int(x / resize_factor), int(y / resize_factor))))
                     r = max(int(w / 3 * 2), h)
-                    if len(world.tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r,
-                                                     predicate=on_border)) <= 2:
+
+                    if r not in border_neighbours:
+                        border_neighbours[r] = numpy.rint(count_neighbours(borders, r))
+
+                    if border_neighbours[r][y,x] <= 2:
                         _draw_a_mountain(target, x, y, w=w, h=h)
-                        world.on_tiles_around_factor(resize_factor, (x, y),
-                                                     radius=r, action=unset_mask)
+                        mountains_mask[y-r:y+r+1,x-r:x+r+1] = 0.0
         if verbose:
             elapsed_time = time.time() - start_time
             print(

--- a/worldengine/model/world.py
+++ b/worldengine/model/world.py
@@ -412,17 +412,6 @@ class World(object):
     # Tiles around
     #
 
-    def on_tiles_around_factor(self, factor, pos, action, radius=1):
-        x, y = pos
-        for dx in range(-radius, radius + 1):
-            nx = x + dx
-            if nx >= 0 and nx / factor < self.width:
-                for dy in range(-radius, radius + 1):
-                    ny = y + dy
-                    if ny >= 0 and ny / factor < self.height and (
-                                    dx != 0 or dy != 0):
-                        action((nx, ny))
-
     def tiles_around(self, pos, radius=1, predicate=None):
         ps = []
         x, y = pos
@@ -432,20 +421,6 @@ class World(object):
                 for dy in range(-radius, radius + 1):
                     ny = y + dy
                     if 0 <= ny < self.height and (dx != 0 or dy != 0):
-                        if predicate is None or predicate((nx, ny)):
-                            ps.append((nx, ny))
-        return ps
-
-    def tiles_around_factor(self, factor, pos, radius=1, predicate=None):
-        ps = []
-        x, y = pos
-        for dx in range(-radius, radius + 1):
-            nx = x + dx
-            if nx >= 0 and nx < self.width * factor:
-                for dy in range(-radius, radius + 1):
-                    ny = y + dy
-                    if ny >= 0 and ny < self.height * factor and (
-                            dx != 0 or dy != 0):
                         if predicate is None or predicate((nx, ny)):
                             ps.append((nx, ny))
         return ps


### PR DESCRIPTION
Hi again,

this more or less completely refactors `draw_ancient_map`. It is part of my effort to get rid of the slow `*_tiles_around_*` functions. 

## Changes #
Almost nothing is where it used to be, again to the point where the diff is almost useless, so let me highlight some changes:

* `find_land_borders` and `find_outer_borders` both use the scaled ocean. So it would be nice if they were in the same scope as to share that. They also both can be expressed in very few lines of code. So I moved them into `draw_ancientmap` proper.
* biome drawing code looked a bit differently for each biome but in the end only three different concepts were used. The new `_draw_biome` caters almost all our biome drawing needs. I'll try to get rid of the glacier special case next, btw.
* this results in verbose mode actually being verbose. 
* masks can be unset with absolutely no hassle using numpy array adressing syntax. No need for custom code there.
* most biomes want to know how many neighbours of them within a radius of 6 or 9 are borders. So I'm caching those values for reference in all biomes. Mountains on the other hand don't know the radius they are going to have in advance so I'm caching borders for every radius that appears, regardless of if it will ever be reused. This is wasteful but not slower than the old `*_tiles_around_*` solution. It gets more advantageous the more mountains are on a map.

## Stats #
Performance of `ancient_map -w seed_7577.world -v --draw-outer-border`: 
* Current master: 1m18s, ~14% of which in `tiles_around_factor`.
* This PR: 1m 11s (i. e. no measurable difference)

Basically this does the same thing equally fast looking better and using ~200 fewer lines of code.

Cheers,
Alex