### PR TITLE
Increase numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ config = {
     'entry_points': {
         'console_scripts': ['worldengine=worldengine.cli.main:main'],
     },
-    'install_requires': ['PyPlatec==1.4.0', 'pypng>=0.0.18', 'numpy>=1.9.2, <= 1.10.0.post2',
+    'install_requires': ['PyPlatec==1.4.0', 'pypng>=0.0.18', 'numpy>=1.22.2',
                          'argparse==1.2.1', 'noise==1.2.2', 'protobuf==3.0.0a3'],
     'license': 'MIT License'
 }


### PR DESCRIPTION
The older numpy versions that were in setup.py failed to install on both systems I tested it on (Ubuntu 20.04 and EndeavourOS).
I bumped the numpy version much higher and now it works.

(This shouldn't affect the tests but some tests failed, maybe because of changes with Python's abstract class module) 